### PR TITLE
Fix reserved root file protection and MCP argument validation

### DIFF
--- a/cmd/okf/mcp.go
+++ b/cmd/okf/mcp.go
@@ -487,6 +487,19 @@ func (s *mcpServer) handleToolCall(req jsonRPCRequest) {
 		desc, _ := callParams.Arguments["description"].(string)
 		body, _ := callParams.Arguments["body"].(string)
 
+		if strings.TrimSpace(conceptType) == "" {
+			s.sendToolResult(req.ID, "Invalid type: argument 'type' is required and cannot be empty", true)
+			return
+		}
+		if strings.TrimSpace(title) == "" {
+			s.sendToolResult(req.ID, "Invalid title: argument 'title' is required and cannot be empty", true)
+			return
+		}
+		if strings.TrimSpace(desc) == "" {
+			s.sendToolResult(req.ID, "Invalid description: argument 'description' is required and cannot be empty", true)
+			return
+		}
+
 		relPath := conceptID
 		if !strings.HasSuffix(relPath, ".md") {
 			relPath += ".md"

--- a/cmd/okf/mcp_test.go
+++ b/cmd/okf/mcp_test.go
@@ -285,6 +285,41 @@ func TestMCPCreate_PathTraversalDenied(t *testing.T) {
 	}
 }
 
+func TestMCPCreate_ValidationAndReservedFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	bundleDir := filepath.Join(tmpDir, "bundle")
+	_ = os.MkdirAll(bundleDir, 0o755)
+	_ = os.WriteFile(filepath.Join(bundleDir, "index.md"), []byte("---\nokf_version: \"0.2\"\n---\n# Bundle\n"), 0o644)
+	_ = os.WriteFile(filepath.Join(bundleDir, "log.md"), []byte("# Log\n"), 0o644)
+
+	inputs := []string{
+		// 1. Missing required field 'type'
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"okf_create","arguments":{"bundle":"` + bundleDir + `","concept_id":"valid-id","title":"Title","description":"Desc"}}}`,
+		// 2. Whitespace-only 'title'
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"okf_create","arguments":{"bundle":"` + bundleDir + `","concept_id":"valid-id","type":"Fact","title":"   ","description":"Desc"}}}`,
+		// 3. Attempt to create AGENTS.md
+		`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"okf_create","arguments":{"bundle":"` + bundleDir + `","concept_id":"AGENTS","type":"Fact","title":"Agents","description":"Desc"}}}`,
+		// 4. Attempt to create AGENTS.md with lower case
+		`{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"okf_create","arguments":{"bundle":"` + bundleDir + `","concept_id":"agents.md","type":"Fact","title":"Agents","description":"Desc"}}}`,
+	}
+
+	responses := runMCPConversation(t, bundleDir, inputs)
+	if len(responses) != len(inputs) {
+		t.Fatalf("Expected %d responses, got %d", len(inputs), len(responses))
+	}
+
+	for i, r := range responses {
+		rMap, ok := r.Result.(map[string]any)
+		if !ok {
+			t.Fatalf("Response %d has unexpected result type: %T", i+1, r.Result)
+		}
+		isError, _ := rMap["isError"].(bool)
+		if !isError {
+			t.Errorf("Expected response %d to have isError: true, got: %+v", i+1, rMap)
+		}
+	}
+}
+
 func TestMCPBundle_PathTraversalDenied(t *testing.T) {
 	tmpDir := t.TempDir()
 	serverRoot := filepath.Join(tmpDir, "server")

--- a/pkg/okf/bundle.go
+++ b/pkg/okf/bundle.go
@@ -271,11 +271,11 @@ func (b *Bundle) buildGraph() {
 			targetRel := targetID + ".md"
 			targetBase := path.Base(targetRel)
 
-			if targetBase == "index.md" || targetBase == "log.md" {
+			if strings.EqualFold(targetBase, "index.md") || strings.EqualFold(targetBase, "log.md") || strings.EqualFold(targetBase, "AGENTS.md") {
 				b.BrokenLinks = append(b.BrokenLinks, BrokenLink{
 					SourceConcept: concept.Path,
 					TargetHref:    href,
-					Reason:        "reserved index.md/log.md is navigation, not a concept",
+					Reason:        "reserved index.md/log.md/AGENTS.md is navigation, not a concept",
 				})
 				continue
 			}

--- a/pkg/okf/mutate.go
+++ b/pkg/okf/mutate.go
@@ -107,7 +107,8 @@ func ValidateConceptID(id string) error {
 	}
 
 	// Check for reserved root filenames
-	if cleaned == "index" || cleaned == "log" {
+	if strings.EqualFold(cleaned, "index") || strings.EqualFold(cleaned, "log") || strings.EqualFold(cleaned, "AGENTS") ||
+		strings.EqualFold(cleaned, "index.md") || strings.EqualFold(cleaned, "log.md") || strings.EqualFold(cleaned, "AGENTS.md") {
 		return fmt.Errorf("concept ID %q is a reserved bundle root document", id)
 	}
 
@@ -134,6 +135,10 @@ func UpdateParentIndex(bundleDir string, c *Concept) error {
 	}
 	if _, err := ensureWithinRoot(bundleDir, indexPath); err != nil {
 		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(indexPath), 0o755); err != nil {
+		return fmt.Errorf("failed to create directory for parent index %q: %w", indexRelPath, err)
 	}
 
 	targetFilename := filepath.Base(c.Path)
@@ -198,8 +203,9 @@ func resolveInBundle(bundleDir, relPath string) (string, error) {
 		return "", fmt.Errorf("path traversal denied: concept path %q escapes bundle directory", relPath)
 	}
 	// Disallow overwriting root reserved files as concept documents
-	if rel == "." || rel == "index.md" || rel == "log.md" {
-		return "", fmt.Errorf("cannot write concept to reserved bundle file %q", rel)
+	if rel == "." || cleanRel == "." || strings.EqualFold(rel, "index.md") || strings.EqualFold(rel, "log.md") || strings.EqualFold(rel, "AGENTS.md") ||
+		strings.EqualFold(cleanRel, "index.md") || strings.EqualFold(cleanRel, "log.md") || strings.EqualFold(cleanRel, "AGENTS.md") {
+		return "", fmt.Errorf("cannot write concept to reserved bundle file %q", relPath)
 	}
 
 	// Security: prevent symlink-based path traversal and arbitrary file overwrite

--- a/pkg/okf/mutate_security_test.go
+++ b/pkg/okf/mutate_security_test.go
@@ -95,15 +95,15 @@ func TestSaveConceptAllowsNestedConcept(t *testing.T) {
 	}
 }
 
-// TestSaveConceptRejectsReservedRootFiles ensures index.md and log.md cannot be
-// overwritten as concept documents.
+// TestSaveConceptRejectsReservedRootFiles ensures index.md, log.md, and AGENTS.md cannot be
+// overwritten as concept documents regardless of letter case.
 func TestSaveConceptRejectsReservedRootFiles(t *testing.T) {
 	bundle := t.TempDir()
 	if err := InitBundle(bundle); err != nil {
 		t.Fatalf("InitBundle: %v", err)
 	}
 
-	for _, reserved := range []string{"index.md", "log.md", "."} {
+	for _, reserved := range []string{"index.md", "log.md", "AGENTS.md", "INDEX.MD", "Log.MD", "agents.md", "."} {
 		c := &Concept{
 			ID:    strings.TrimSuffix(reserved, ".md"),
 			Path:  reserved,
@@ -143,8 +143,13 @@ func TestValidateConceptID(t *testing.T) {
 		"sub/../../escaped",
 		"index",
 		"log",
+		"AGENTS",
 		"index.md",
 		"log.md",
+		"AGENTS.md",
+		"INDEX.MD",
+		"Log.MD",
+		"agents.md",
 		"",
 		".",
 		"..",


### PR DESCRIPTION
This change addresses security audit findings from docs/SECURITY_AUDIT.md:
1. Protects AGENTS.md alongside index.md and log.md as reserved bundle root documents.
2. Uses case-insensitive comparison (strings.EqualFold) for reserved root files to prevent case-variant overwrite bypasses.
3. Ensures UpdateParentIndex creates parent directories if missing.
4. Validates required string arguments (type, title, description) in MCP okf_create tool calls.
5. Adds adversarial unit tests in pkg/okf/mutate_security_test.go and cmd/okf/mcp_test.go.

---
*PR created automatically by Jules for task [12578030968208081575](https://jules.google.com/task/12578030968208081575) started by @sknr*