### PR TITLE
security: harden boundary containment and reserved file checks

### DIFF
--- a/cmd/okf/mcp.go
+++ b/cmd/okf/mcp.go
@@ -396,19 +396,40 @@ func (s *mcpServer) resolveBundleDir(callParams mcpToolCallParams) (string, erro
 			absTarget = filepath.Join(s.rootDir, target)
 		}
 
-		evalTarget, err := filepath.EvalSymlinks(absTarget)
-		if err == nil {
-			absTarget, _ = filepath.Abs(evalTarget)
-		} else {
-			absTarget, _ = filepath.Abs(absTarget)
+		// Walk up to find the closest ancestor that exists and evaluate its symlinks
+		curr := absTarget
+		var missingParts []string
+		for {
+			_, lstatErr := os.Lstat(curr)
+			if lstatErr == nil {
+				break
+			}
+			missingParts = append([]string{filepath.Base(curr)}, missingParts...)
+			parent := filepath.Dir(curr)
+			if parent == curr {
+				break
+			}
+			curr = parent
 		}
 
-		rel, err := filepath.Rel(absRoot, absTarget)
+		realCurr, err := filepath.EvalSymlinks(curr)
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve bundle path %q: %w", target, err)
+		}
+		realCurr, err = filepath.Abs(realCurr)
+		if err != nil {
+			return "", err
+		}
+
+		parts := append([]string{realCurr}, missingParts...)
+		realTarget := filepath.Join(parts...)
+
+		rel, err := filepath.Rel(absRoot, realTarget)
 		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 			return "", fmt.Errorf("bundle directory %q escapes server root %q", target, s.rootDir)
 		}
 
-		return absTarget, nil
+		return realTarget, nil
 	}
 
 	return target, nil

--- a/cmd/okf/mcp_test.go
+++ b/cmd/okf/mcp_test.go
@@ -189,6 +189,76 @@ func TestMCPToolCalls(t *testing.T) {
 	}
 }
 
+func TestMCPBundle_SymlinkAncestorTraversalDenied(t *testing.T) {
+	tmpDir := t.TempDir()
+	serverRoot := filepath.Join(tmpDir, "server")
+	bundleDir := filepath.Join(serverRoot, "knowledge")
+	outsideDir := filepath.Join(tmpDir, "outside")
+
+	_ = os.MkdirAll(bundleDir, 0o755)
+	_ = os.MkdirAll(outsideDir, 0o755)
+	_ = os.WriteFile(filepath.Join(bundleDir, "index.md"), []byte("---\nokf_version: \"0.2\"\n---\n# Root\n"), 0o644)
+	_ = os.WriteFile(filepath.Join(bundleDir, "log.md"), []byte("# Log\n"), 0o644)
+
+	// Symlink inside serverRoot pointing to outsideDir
+	symlinkPath := filepath.Join(serverRoot, "sym_outside")
+	if err := os.Symlink(outsideDir, symlinkPath); err != nil {
+		t.Skipf("Symlinks not supported: %v", err)
+	}
+
+	inputs := []string{
+		// Attempt bundle creation via symlinked ancestor pointing outside serverRoot
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"okf_create","arguments":{"bundle":"sym_outside/nonexistent_bundle","concept_id":"evil","type":"Fact","title":"Evil","description":"Should fail"}}}`,
+	}
+
+	responses := runMCPConversation(t, bundleDir, inputs)
+	if len(responses) != 1 {
+		t.Fatalf("Expected 1 response, got %d", len(responses))
+	}
+
+	rMap, ok := responses[0].Result.(map[string]any)
+	if !ok {
+		t.Fatalf("Response result is not map[string]any: %T", responses[0].Result)
+	}
+	if isError, _ := rMap["isError"].(bool); !isError {
+		t.Errorf("Expected response to have isError: true, got: %+v", rMap)
+	}
+
+	// Verify nothing was created in outsideDir
+	entries, _ := os.ReadDir(outsideDir)
+	if len(entries) > 0 {
+		t.Fatalf("Security failure: files created in outside directory: %v", entries)
+	}
+}
+
+func TestMCPCreate_SubdirectoryReservedFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	bundleDir := filepath.Join(tmpDir, "bundle")
+	_ = os.MkdirAll(bundleDir, 0o755)
+	_ = os.WriteFile(filepath.Join(bundleDir, "index.md"), []byte("---\nokf_version: \"0.2\"\n---\n# Bundle\n"), 0o644)
+	_ = os.WriteFile(filepath.Join(bundleDir, "log.md"), []byte("# Log\n"), 0o644)
+
+	inputs := []string{
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"okf_create","arguments":{"bundle":"` + bundleDir + `","concept_id":"sub/index","type":"Fact","title":"Sub Index","description":"Desc"}}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"okf_create","arguments":{"bundle":"` + bundleDir + `","concept_id":"sub/index.md","type":"Fact","title":"Sub Index MD","description":"Desc"}}}`,
+	}
+
+	responses := runMCPConversation(t, bundleDir, inputs)
+	if len(responses) != 2 {
+		t.Fatalf("Expected 2 responses, got %d", len(responses))
+	}
+
+	for i, r := range responses {
+		rMap, ok := r.Result.(map[string]any)
+		if !ok {
+			t.Fatalf("Response %d has unexpected result type: %T", i+1, r.Result)
+		}
+		if isError, _ := rMap["isError"].(bool); !isError {
+			t.Errorf("Expected response %d to have isError: true, got: %+v", i+1, rMap)
+		}
+	}
+}
+
 func TestMCPUnknownMethodAndParseError(t *testing.T) {
 	inputs := []string{
 		`invalid json line`,

--- a/pkg/okf/bundle.go
+++ b/pkg/okf/bundle.go
@@ -192,7 +192,9 @@ func LoadBundle(root string) (*Bundle, error) {
 		}
 
 		if name == "log.md" {
-			b.LogContent = content
+			if rel == "log.md" {
+				b.LogContent = content
+			}
 			return nil
 		}
 

--- a/pkg/okf/mutate.go
+++ b/pkg/okf/mutate.go
@@ -106,10 +106,13 @@ func ValidateConceptID(id string) error {
 		return fmt.Errorf("concept ID %q escapes bundle directory", id)
 	}
 
-	// Check for reserved root filenames
-	if strings.EqualFold(cleaned, "index") || strings.EqualFold(cleaned, "log") || strings.EqualFold(cleaned, "AGENTS") ||
-		strings.EqualFold(cleaned, "index.md") || strings.EqualFold(cleaned, "log.md") || strings.EqualFold(cleaned, "AGENTS.md") {
-		return fmt.Errorf("concept ID %q is a reserved bundle root document", id)
+	// Check for reserved filenames (index.md anywhere, root log.md, root AGENTS.md)
+	base := filepath.Base(cleaned)
+	normClean := filepath.ToSlash(cleaned)
+	if strings.EqualFold(base, "index") || strings.EqualFold(base, "index.md") ||
+		strings.EqualFold(normClean, "log") || strings.EqualFold(normClean, "log.md") ||
+		strings.EqualFold(normClean, "AGENTS") || strings.EqualFold(normClean, "AGENTS.md") {
+		return fmt.Errorf("concept ID %q is a reserved bundle document", id)
 	}
 
 	return nil
@@ -202,18 +205,40 @@ func resolveInBundle(bundleDir, relPath string) (string, error) {
 	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return "", fmt.Errorf("path traversal denied: concept path %q escapes bundle directory", relPath)
 	}
-	// Disallow overwriting root reserved files as concept documents
-	if rel == "." || cleanRel == "." || strings.EqualFold(rel, "index.md") || strings.EqualFold(rel, "log.md") || strings.EqualFold(rel, "AGENTS.md") ||
-		strings.EqualFold(cleanRel, "index.md") || strings.EqualFold(cleanRel, "log.md") || strings.EqualFold(cleanRel, "AGENTS.md") {
+	// Check reserved filenames on relative path (index.md anywhere, root log.md, root AGENTS.md)
+	relBase := filepath.Base(cleanRel)
+	normRel := filepath.ToSlash(rel)
+	if rel == "." || cleanRel == "." ||
+		strings.EqualFold(relBase, "index") || strings.EqualFold(relBase, "index.md") ||
+		strings.EqualFold(normRel, "log.md") || strings.EqualFold(normRel, "AGENTS.md") {
 		return "", fmt.Errorf("cannot write concept to reserved bundle file %q", relPath)
 	}
 
 	// Security: prevent symlink-based path traversal and arbitrary file overwrite
-	if _, err := ensureWithinRoot(bundleDir, full); err != nil {
+	realTarget, err := ensureWithinRoot(bundleDir, full)
+	if err != nil {
 		return "", err
 	}
 
-	return full, nil
+	// Check reserved filenames and file type on symlink-resolved target
+	targetBase := filepath.Base(realTarget)
+	realRoot, err := filepath.EvalSymlinks(bundleDir)
+	if err != nil {
+		realRoot, _ = filepath.Abs(bundleDir)
+	} else {
+		realRoot, _ = filepath.Abs(realRoot)
+	}
+	targetRel, _ := filepath.Rel(realRoot, realTarget)
+	targetRel = filepath.ToSlash(targetRel)
+
+	if strings.EqualFold(targetBase, "index.md") || strings.EqualFold(targetRel, "log.md") || strings.EqualFold(targetRel, "AGENTS.md") {
+		return "", fmt.Errorf("cannot write concept to reserved bundle file %q", relPath)
+	}
+	if !strings.HasSuffix(strings.ToLower(realTarget), ".md") {
+		return "", fmt.Errorf("concept target %q must be a markdown (.md) file", relPath)
+	}
+
+	return realTarget, nil
 }
 
 // sanitizeConceptMetadata validates that concept metadata fields do not contain

--- a/pkg/okf/mutate_security_test.go
+++ b/pkg/okf/mutate_security_test.go
@@ -335,6 +335,108 @@ func TestLoadBundleRejectsExternalSymlinks(t *testing.T) {
 	}
 }
 
+// TestSaveConceptRejectsSubdirectoryReservedFiles verifies that reserved files (index.md anywhere, root log.md, root AGENTS.md)
+// cannot be targeted as concepts in subdirectories.
+func TestSaveConceptRejectsSubdirectoryReservedFiles(t *testing.T) {
+	bundleDir := t.TempDir()
+	if err := InitBundle(bundleDir); err != nil {
+		t.Fatalf("InitBundle failed: %v", err)
+	}
+
+	reservedPaths := []string{
+		"sub/index.md",
+		"sub/index",
+		"sub/dir/index.md",
+		"log.md",
+		"AGENTS.md",
+	}
+
+	for _, relPath := range reservedPaths {
+		c := &Concept{
+			ID:    strings.TrimSuffix(relPath, ".md"),
+			Path:  relPath,
+			Title: "Reserved Overwrite Attempt",
+			Type:  "Fact",
+		}
+		if err := SaveConcept(bundleDir, c, true, false, false, "attacker"); err == nil {
+			t.Errorf("SaveConcept(%q) expected error for reserved file, got nil", relPath)
+		}
+		if err := ValidateConceptID(c.ID); err == nil {
+			t.Errorf("ValidateConceptID(%q) expected error for reserved file, got nil", c.ID)
+		}
+	}
+}
+
+// TestSaveConceptRejectsSymlinkToReservedOrNonMarkdown verifies that SaveConcept refuses to write through symlinks
+// targeting reserved documents or non-markdown files within the bundle.
+func TestSaveConceptRejectsSymlinkToReservedOrNonMarkdown(t *testing.T) {
+	bundleDir := t.TempDir()
+	if err := InitBundle(bundleDir); err != nil {
+		t.Fatalf("InitBundle failed: %v", err)
+	}
+
+	// Create non-markdown file inside bundle
+	dataJsonPath := filepath.Join(bundleDir, "data.json")
+	if err := os.WriteFile(dataJsonPath, []byte(`{"key":"value"}`), 0o644); err != nil {
+		t.Fatalf("WriteFile data.json: %v", err)
+	}
+
+	// Create symlink concept_link.md -> data.json
+	symlinkNonMD := filepath.Join(bundleDir, "concept_json.md")
+	if err := os.Symlink("data.json", symlinkNonMD); err != nil {
+		t.Skipf("Symlinks not supported: %v", err)
+	}
+
+	// Create symlink concept_index.md -> index.md
+	symlinkIndex := filepath.Join(bundleDir, "concept_index.md")
+	if err := os.Symlink("index.md", symlinkIndex); err != nil {
+		t.Skipf("Symlinks not supported: %v", err)
+	}
+
+	cJSON := &Concept{Path: "concept_json.md", Title: "JSON", Type: "Fact", Body: "PWNED"}
+	if err := SaveConcept(bundleDir, cJSON, false, false, false, "attacker"); err == nil {
+		t.Errorf("Expected SaveConcept through symlink to non-markdown file to fail, got nil")
+	}
+
+	cIndex := &Concept{Path: "concept_index.md", Title: "Index", Type: "Fact", Body: "PWNED"}
+	if err := SaveConcept(bundleDir, cIndex, false, false, false, "attacker"); err == nil {
+		t.Errorf("Expected SaveConcept through symlink to index.md to fail, got nil")
+	}
+
+	// Ensure index.md content was preserved
+	idxContent, _ := os.ReadFile(filepath.Join(bundleDir, "index.md"))
+	if strings.Contains(string(idxContent), "PWNED") {
+		t.Errorf("index.md was overwritten via symlink!")
+	}
+}
+
+// TestLoadBundleSubdirectoryLogIsolation verifies that a log.md in a subdirectory does not overwrite root LogContent.
+func TestLoadBundleSubdirectoryLogIsolation(t *testing.T) {
+	bundleDir := t.TempDir()
+	if err := InitBundle(bundleDir); err != nil {
+		t.Fatalf("InitBundle failed: %v", err)
+	}
+
+	subDir := filepath.Join(bundleDir, "sub")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	subLogPath := filepath.Join(subDir, "log.md")
+	if err := os.WriteFile(subLogPath, []byte("## 2000-01-01\n* Sub log\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile sub/log.md: %v", err)
+	}
+
+	b, err := LoadBundle(bundleDir)
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	if strings.Contains(b.LogContent, "Sub log") {
+		t.Errorf("Root LogContent was overwritten by sub/log.md: %s", b.LogContent)
+	}
+}
+
 // TestLoadBundleAllowsInternalSymlinks verifies that symlinks pointing within the bundle are allowed.
 func TestLoadBundleAllowsInternalSymlinks(t *testing.T) {
 	bundleDir := t.TempDir()


### PR DESCRIPTION
Adversarial security audit and hardening of okf-agent-memory:
1. Resolved MCP server root confinement bypass for non-existent target paths with symlinked ancestors.
2. Prevented writing/creating reserved index.md files in subdirectories and root log.md / AGENTS.md.
3. Blocked writing through symlinks targeting reserved files or non-markdown files.
4. Isolated LogContent loading strictly to root log.md.
5. Added adversarial unit tests in pkg/okf/mutate_security_test.go and cmd/okf/mcp_test.go.

---
*PR created automatically by Jules for task [11393278416355006323](https://jules.google.com/task/11393278416355006323) started by @sknr*