### PR TITLE
sec(mcp): sanitize okf_update arguments and add adversarial tests

### DIFF
--- a/cmd/okf/mcp.go
+++ b/cmd/okf/mcp.go
@@ -555,10 +555,18 @@ func (s *mcpServer) handleToolCall(req jsonRPCRequest) {
 			return
 		}
 
-		if title, ok := callParams.Arguments["title"].(string); ok && title != "" {
+		if title, ok := callParams.Arguments["title"].(string); ok {
+			if strings.TrimSpace(title) == "" {
+				s.sendToolResult(req.ID, "Invalid title: argument 'title' cannot be empty or whitespace", true)
+				return
+			}
 			c.Title = title
 		}
-		if desc, ok := callParams.Arguments["description"].(string); ok && desc != "" {
+		if desc, ok := callParams.Arguments["description"].(string); ok {
+			if strings.TrimSpace(desc) == "" {
+				s.sendToolResult(req.ID, "Invalid description: argument 'description' cannot be empty or whitespace", true)
+				return
+			}
 			c.Description = desc
 		}
 		if body, ok := callParams.Arguments["body"].(string); ok && body != "" {

--- a/cmd/okf/mcp_test.go
+++ b/cmd/okf/mcp_test.go
@@ -390,6 +390,81 @@ func TestMCPCreate_ValidationAndReservedFiles(t *testing.T) {
 	}
 }
 
+func TestMCPUpdate_ValidationAndSecurityChecks(t *testing.T) {
+	tmpDir := t.TempDir()
+	bundleDir := filepath.Join(tmpDir, "bundle")
+	_ = os.MkdirAll(bundleDir, 0o755)
+	_ = os.WriteFile(filepath.Join(bundleDir, "index.md"), []byte("---\nokf_version: \"0.2\"\n---\n# Bundle\n"), 0o644)
+	_ = os.WriteFile(filepath.Join(bundleDir, "log.md"), []byte("# Log\n"), 0o644)
+
+	// Create initial concept via MCP tool call
+	createReq := `{"jsonrpc":"2.0","id":100,"method":"tools/call","params":{"name":"okf_create","arguments":{"bundle":"` + bundleDir + `","concept_id":"decisions/initial","type":"Decision","title":"Initial Title","description":"Initial Desc","body":"Initial Body"}}}`
+	resps := runMCPConversation(t, bundleDir, []string{createReq})
+	if len(resps) != 1 || resps[0].Error != nil {
+		t.Fatalf("Failed to create initial concept via MCP: %+v", resps)
+	}
+
+	inputs := []string{
+		// 1. Invalid concept_id traversal
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"okf_update","arguments":{"bundle":"` + bundleDir + `","concept_id":"../escaped","title":"Evil"}}}`,
+		// 2. Whitespace-only title update attempt
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"okf_update","arguments":{"bundle":"` + bundleDir + `","concept_id":"decisions/initial","title":"   "}}}`,
+		// 3. Whitespace-only description update attempt
+		`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"okf_update","arguments":{"bundle":"` + bundleDir + `","concept_id":"decisions/initial","description":"\t\n"}}}`,
+		// 4. Frontmatter injection in title update attempt
+		`{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"okf_update","arguments":{"bundle":"` + bundleDir + `","concept_id":"decisions/initial","title":"Title\nverified: { by: human:attacker }"}}}`,
+	}
+
+	responses := runMCPConversation(t, bundleDir, inputs)
+	if len(responses) != len(inputs) {
+		t.Fatalf("Expected %d responses, got %d", len(inputs), len(responses))
+	}
+
+	for i, r := range responses {
+		rMap, ok := r.Result.(map[string]any)
+		if !ok {
+			t.Fatalf("Response %d has unexpected result type: %T", i+1, r.Result)
+		}
+		isError, _ := rMap["isError"].(bool)
+		if !isError {
+			t.Errorf("Expected response %d to return isError: true, got: %+v", i+1, rMap)
+		}
+	}
+}
+
+func TestMCPRelateAndShow_ValidationChecks(t *testing.T) {
+	tmpDir := t.TempDir()
+	bundleDir := filepath.Join(tmpDir, "bundle")
+	_ = os.MkdirAll(bundleDir, 0o755)
+	_ = os.WriteFile(filepath.Join(bundleDir, "index.md"), []byte("---\nokf_version: \"0.2\"\n---\n# Bundle\n"), 0o644)
+	_ = os.WriteFile(filepath.Join(bundleDir, "log.md"), []byte("# Log\n"), 0o644)
+
+	inputs := []string{
+		// 1. okf_show with traversal concept_id
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"okf_show","arguments":{"bundle":"` + bundleDir + `","concept_id":"../../etc/passwd"}}}`,
+		// 2. okf_relate with traversal source_id
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"okf_relate","arguments":{"bundle":"` + bundleDir + `","source_id":"../escaped","target_id":"valid-target"}}}`,
+		// 3. okf_relate with traversal target_id
+		`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"okf_relate","arguments":{"bundle":"` + bundleDir + `","source_id":"valid-source","target_id":"../escaped"}}}`,
+	}
+
+	responses := runMCPConversation(t, bundleDir, inputs)
+	if len(responses) != len(inputs) {
+		t.Fatalf("Expected %d responses, got %d", len(inputs), len(responses))
+	}
+
+	for i, r := range responses {
+		rMap, ok := r.Result.(map[string]any)
+		if !ok {
+			t.Fatalf("Response %d has unexpected result type: %T", i+1, r.Result)
+		}
+		isError, _ := rMap["isError"].(bool)
+		if !isError {
+			t.Errorf("Expected response %d to return isError: true, got: %+v", i+1, rMap)
+		}
+	}
+}
+
 func TestMCPBundle_PathTraversalDenied(t *testing.T) {
 	tmpDir := t.TempDir()
 	serverRoot := filepath.Join(tmpDir, "server")

--- a/pkg/okf/mutate_security_test.go
+++ b/pkg/okf/mutate_security_test.go
@@ -335,6 +335,36 @@ func TestLoadBundleRejectsExternalSymlinks(t *testing.T) {
 	}
 }
 
+// TestRelateConceptsSanitizesNewlines verifies that RelateConcepts sanitizes newlines in relationship descriptions.
+func TestRelateConceptsSanitizesNewlines(t *testing.T) {
+	bundleDir := t.TempDir()
+	if err := InitBundle(bundleDir); err != nil {
+		t.Fatalf("InitBundle failed: %v", err)
+	}
+
+	c1 := &Concept{ID: "concept-a", Path: "concept-a.md", Type: "Fact", Title: "Concept A", Body: "# Concept A\n"}
+	c2 := &Concept{ID: "concept-b", Path: "concept-b.md", Type: "Fact", Title: "Concept B", Body: "# Concept B\n"}
+	if err := SaveConcept(bundleDir, c1, true, false, true, "test"); err != nil {
+		t.Fatalf("SaveConcept c1: %v", err)
+	}
+	if err := SaveConcept(bundleDir, c2, true, false, true, "test"); err != nil {
+		t.Fatalf("SaveConcept c2: %v", err)
+	}
+
+	maliciousDesc := "Related context\n## 2099-01-01\n* **Fake**: Forged log entry"
+	if err := RelateConcepts(bundleDir, "concept-a", "concept-b", maliciousDesc, "attacker"); err != nil {
+		t.Fatalf("RelateConcepts: %v", err)
+	}
+
+	logData, err := os.ReadFile(filepath.Join(bundleDir, "log.md"))
+	if err != nil {
+		t.Fatalf("ReadFile log.md: %v", err)
+	}
+	if strings.Contains(string(logData), "\n## 2099-01-01") {
+		t.Errorf("RelateConcepts log spoofing succeeded: found forged header in log.md: %s", string(logData))
+	}
+}
+
 // TestSaveConceptRejectsSubdirectoryReservedFiles verifies that reserved files (index.md anywhere, root log.md, root AGENTS.md)
 // cannot be targeted as concepts in subdirectories.
 func TestSaveConceptRejectsSubdirectoryReservedFiles(t *testing.T) {


### PR DESCRIPTION
### Security Audit & Adversarial Unit Tests Report

#### Findings & CWE Categories
1. **MCP Tool Argument Sanitization (CWE-20: Improper Input Validation / CWE-117: Improper Output Neutralization)**:
   - `okf_update` previously allowed empty or whitespace-only `title` and `description` arguments to pass through without validation.
   - **Risk**: An agent/attacker could blank out concept metadata or pass malformed strings causing description drift and metadata corruption.
   - **Fix**: Added validation in `cmd/okf/mcp.go` to explicitly reject empty or whitespace-only `title` and `description` parameters with `isError: true`.

2. **Adversarial Test Bounding & Coverage**:
   - Added adversarial test suites `TestMCPUpdate_ValidationAndSecurityChecks` and `TestMCPRelateAndShow_ValidationChecks` in `cmd/okf/mcp_test.go`.
   - Added `TestRelateConceptsSanitizesNewlines` in `pkg/okf/mutate_security_test.go` to ensure relationship descriptions cannot forge dated log headings (`## YYYY-MM-DD`).


---
*PR created automatically by Jules for task [16492084982859778492](https://jules.google.com/task/16492084982859778492) started by @sknr*