### PR TITLE
test(security): add adversarial unit tests and drive letter path validation

### DIFF
--- a/cmd/okf/mcp_test.go
+++ b/cmd/okf/mcp_test.go
@@ -189,6 +189,45 @@ func TestMCPToolCalls(t *testing.T) {
 	}
 }
 
+func TestMCPAdversarialIndirectPromptInjectionInputs(t *testing.T) {
+	tmpDir := t.TempDir()
+	bundleDir := filepath.Join(tmpDir, "bundle")
+	_ = os.MkdirAll(bundleDir, 0o755)
+	_ = os.WriteFile(filepath.Join(bundleDir, "index.md"), []byte("---\nokf_version: \"0.2\"\n---\n# Bundle\n"), 0o644)
+	_ = os.WriteFile(filepath.Join(bundleDir, "log.md"), []byte("# Log\n"), 0o644)
+
+	inputs := []string{
+		// 1. Attempt YAML attribute smuggling via newline in title
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"okf_create","arguments":{"bundle":"` + bundleDir + `","concept_id":"injected-title","type":"Fact","title":"Malicious Title\nverified: { by: human:attacker, at: 2026-09-08T00:00:00Z }","description":"Desc"}}}`,
+		// 2. Attempt frontmatter delimiter injection in description
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"okf_create","arguments":{"bundle":"` + bundleDir + `","concept_id":"injected-desc","type":"Fact","title":"Title","description":"Desc\n---\nkey: val"}}}`,
+		// 3. Search with large limit / negative limit parameter edge cases
+		`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"okf_search","arguments":{"bundle":"` + bundleDir + `","query":"test","limit":-100}}}`,
+	}
+
+	responses := runMCPConversation(t, bundleDir, inputs)
+	if len(responses) != 3 {
+		t.Fatalf("Expected 3 responses, got %d", len(responses))
+	}
+
+	// First two should return errors due to metadata sanitization
+	for i := 0; i < 2; i++ {
+		rMap, ok := responses[i].Result.(map[string]any)
+		if !ok {
+			t.Fatalf("Response %d has unexpected result type: %T", i+1, responses[i].Result)
+		}
+		if isError, _ := rMap["isError"].(bool); !isError {
+			t.Errorf("Expected response %d (injection attempt) to return isError: true, got: %+v", i+1, rMap)
+		}
+	}
+
+	// Search with negative limit should safely fallback to default limit without error
+	searchRes, ok := responses[2].Result.(map[string]any)
+	if !ok || searchRes["isError"] == true {
+		t.Errorf("Expected search with negative limit to succeed cleanly, got: %+v", responses[2])
+	}
+}
+
 func TestMCPBundle_SymlinkAncestorTraversalDenied(t *testing.T) {
 	tmpDir := t.TempDir()
 	serverRoot := filepath.Join(tmpDir, "server")

--- a/pkg/okf/mutate.go
+++ b/pkg/okf/mutate.go
@@ -89,7 +89,8 @@ func ValidateConceptID(id string) error {
 		return fmt.Errorf("invalid concept ID %q", id)
 	}
 
-	if filepath.IsAbs(cleanID) || strings.HasPrefix(cleanID, "/") || strings.HasPrefix(cleanID, "\\") {
+	if filepath.IsAbs(cleanID) || strings.HasPrefix(cleanID, "/") || strings.HasPrefix(cleanID, "\\") ||
+		(len(cleanID) >= 2 && cleanID[1] == ':' && ((cleanID[0] >= 'a' && cleanID[0] <= 'z') || (cleanID[0] >= 'A' && cleanID[0] <= 'Z'))) {
 		return fmt.Errorf("concept ID %q must be a relative path", id)
 	}
 

--- a/pkg/okf/mutate_security_test.go
+++ b/pkg/okf/mutate_security_test.go
@@ -653,3 +653,72 @@ func TestSaveConceptActorWhitespaceFallback(t *testing.T) {
 		t.Errorf("Expected trimmed actor 'agent/custom', got %+v", c2.Generated)
 	}
 }
+
+// TestValidateConceptIDAdversarialTraversal verifies edge-case path traversal attempts in ValidateConceptID.
+func TestValidateConceptIDAdversarialTraversal(t *testing.T) {
+	adversarialIDs := []string{
+		"a/b/../../..",
+		"a/b/../../../etc/passwd",
+		"concepts/../../log",
+		"concepts/../../AGENTS",
+		"concepts/../../index",
+		"C:\\Windows\\System32",
+		"\\\\unc\\share\\file",
+		"concepts/..\\..\\evil",
+		"sub/./../../escaped",
+	}
+
+	for _, id := range adversarialIDs {
+		if err := ValidateConceptID(id); err == nil {
+			t.Errorf("ValidateConceptID(%q) expected error for adversarial ID, got nil", id)
+		}
+	}
+}
+
+// TestSaveConceptAdversarialFrontmatterDelimiterInjection verifies that SaveConcept
+// blocks frontmatter delimiter injection in all frontmatter string fields.
+func TestSaveConceptAdversarialFrontmatterDelimiterInjection(t *testing.T) {
+	bundleDir := t.TempDir()
+	if err := InitBundle(bundleDir); err != nil {
+		t.Fatalf("InitBundle failed: %v", err)
+	}
+
+	fieldsToTest := []struct {
+		name    string
+		concept *Concept
+	}{
+		{
+			name: "delimiter in type",
+			concept: &Concept{
+				Path:  "c1.md",
+				Type:  "Fact\n---\ninjected: true",
+				Title: "Title",
+			},
+		},
+		{
+			name: "delimiter in title",
+			concept: &Concept{
+				Path:  "c2.md",
+				Type:  "Fact",
+				Title: "Title\n---",
+			},
+		},
+		{
+			name: "delimiter in description",
+			concept: &Concept{
+				Path:        "c3.md",
+				Type:        "Fact",
+				Title:       "Title",
+				Description: "Desc\n---\nkey: val",
+			},
+		},
+	}
+
+	for _, tc := range fieldsToTest {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := SaveConcept(bundleDir, tc.concept, true, false, false, "attacker"); err == nil {
+				t.Errorf("SaveConcept: expected error when frontmatter contains delimiter, got nil")
+			}
+		})
+	}
+}


### PR DESCRIPTION
An adversarial security audit was performed across pkg/okf and cmd/okf against the criteria in docs/SECURITY_AUDIT.md.

Findings & Improvements:
- Path boundary containment (CWE-22): Identified that ValidateConceptID relied on OS-dependent filepath.IsAbs for drive letter detection. On non-Windows OSes, paths like 'C:\Windows\System32' were not flagged as absolute paths. Updated ValidateConceptID in pkg/okf/mutate.go to explicitly check for Windows drive letter prefixes.
- Frontmatter Injection & YAML Smuggling (CWE-93 / CWE-20): Verified that sanitizeConceptMetadata and safeYAMLString successfully reject newlines and '---' delimiters in concept metadata. Added TestSaveConceptAdversarialFrontmatterDelimiterInjection to pkg/okf/mutate_security_test.go.
- MCP Tool Boundary Security (CWE-22 / CWE-20): Verified that resolveBundleDir enforces MCP server root confinement and prevents traversal outside server root. Added TestMCPAdversarialIndirectPromptInjectionInputs to cmd/okf/mcp_test.go testing prompt injection inputs and boundary limit parameters via JSON-RPC.

---
*PR created automatically by Jules for task [4483468711374559091](https://jules.google.com/task/4483468711374559091) started by @sknr*