### PR TITLE
fix(cli): preserve flag values without bundle path

### DIFF
--- a/cmd/okf/main.go
+++ b/cmd/okf/main.go
@@ -108,28 +108,22 @@ Flags (general):
 }
 
 func defaultBundle(args []string) (string, []string) {
-	var bundleDir string
-	var remaining []string
-
-	for i := range args {
-		arg := args[i]
-		if !strings.HasPrefix(arg, "-") && bundleDir == "" {
-			bundleDir = arg
-		} else {
-			remaining = append(remaining, arg)
-		}
+	// Look for ./knowledge or default to current directory.
+	fallback := "."
+	if info, err := os.Stat("knowledge"); err == nil && info.IsDir() {
+		fallback = "knowledge"
 	}
+	return splitOptionalPath(args, fallback)
+}
 
-	if bundleDir == "" {
-		// Look for ./knowledge or default to current directory
-		if info, err := os.Stat("knowledge"); err == nil && info.IsDir() {
-			bundleDir = "knowledge"
-		} else {
-			bundleDir = "."
-		}
+// splitOptionalPath consumes an optional positional path only when it is the
+// first argument. Everything else belongs to the command's FlagSet, including
+// values for flags such as "--limit 3" and "--type Fact".
+func splitOptionalPath(args []string, fallback string) (string, []string) {
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		return args[0], args[1:]
 	}
-
-	return bundleDir, remaining
+	return fallback, args
 }
 
 func cmdValidate(args []string) {
@@ -531,17 +525,7 @@ func cmdInit(args []string) {
 }
 
 func cmdBootstrap(args []string) {
-	targetDir := "."
-	var subArgs []string
-
-	for i := range args {
-		arg := args[i]
-		if !strings.HasPrefix(arg, "-") && targetDir == "." {
-			targetDir = arg
-		} else {
-			subArgs = append(subArgs, arg)
-		}
-	}
+	targetDir, subArgs := splitOptionalPath(args, ".")
 
 	fs := flag.NewFlagSet("bootstrap", flag.ExitOnError)
 	name := fs.String("name", "", "Project name (defaults to target directory name)")

--- a/cmd/okf/main_test.go
+++ b/cmd/okf/main_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitOptionalPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		fallback string
+		wantPath string
+		wantArgs []string
+	}{
+		{
+			name:     "flags only",
+			args:     []string{"--limit", "3", "--json"},
+			fallback: "knowledge",
+			wantPath: "knowledge",
+			wantArgs: []string{"--limit", "3", "--json"},
+		},
+		{
+			name:     "explicit path before flags",
+			args:     []string{"custom-bundle", "--limit", "3"},
+			fallback: "knowledge",
+			wantPath: "custom-bundle",
+			wantArgs: []string{"--limit", "3"},
+		},
+		{
+			name:     "valued create flags",
+			args:     []string{"--type", "Fact", "--title", "Demo", "--desc", "Text"},
+			fallback: "knowledge",
+			wantPath: "knowledge",
+			wantArgs: []string{"--type", "Fact", "--title", "Demo", "--desc", "Text"},
+		},
+		{
+			name:     "valued update flags",
+			args:     []string{"--desc", "Updated text", "--actor", "agent/test"},
+			fallback: "knowledge",
+			wantPath: "knowledge",
+			wantArgs: []string{"--desc", "Updated text", "--actor", "agent/test"},
+		},
+		{
+			name:     "valued relate flags",
+			args:     []string{"--desc", "Relationship context", "--actor", "agent/test"},
+			fallback: "knowledge",
+			wantPath: "knowledge",
+			wantArgs: []string{"--desc", "Relationship context", "--actor", "agent/test"},
+		},
+		{
+			name:     "valued bootstrap flags",
+			args:     []string{"--name", "Demo", "--no-skill"},
+			fallback: ".",
+			wantPath: ".",
+			wantArgs: []string{"--name", "Demo", "--no-skill"},
+		},
+		{
+			name:     "no arguments",
+			fallback: ".",
+			wantPath: ".",
+			wantArgs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPath, gotArgs := splitOptionalPath(tt.args, tt.fallback)
+			if gotPath != tt.wantPath {
+				t.Fatalf("splitOptionalPath() path = %q, want %q", gotPath, tt.wantPath)
+			}
+			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+				t.Fatalf("splitOptionalPath() args = %#v, want %#v", gotArgs, tt.wantArgs)
+			}
+		})
+	}
+}

--- a/knowledge/architecture/cli-argument-boundary.md
+++ b/knowledge/architecture/cli-argument-boundary.md
@@ -1,0 +1,11 @@
+---
+type: Decision
+title: CLI Optional Path Boundary
+description: "CLI commands consume an optional bundle or target path only from the first remaining argument, preserving all subsequent flag values."
+tags: [cli, arguments, flags, tooling]
+generated: { by: agent/codex, at: "2026-09-10T04:09:20Z" }
+---
+
+# CLI Optional Path Boundary
+
+Optional paths are positional-only and must precede flags. Flag values stay with the command FlagSet. See [Go Single-Binary CLI and MCP Architecture Decision](tooling-decision.md).

--- a/knowledge/architecture/index.md
+++ b/knowledge/architecture/index.md
@@ -3,3 +3,4 @@
 * [5-Layer System Architecture](layers.md) - Structural separation of concerns across the OKF specification, agent convention, skills, deterministic tooling, and knowledge corpus.
 * [Go Single-Binary CLI & MCP Architecture Decision](tooling-decision.md) - Architectural decision to implement the deterministic OKF tooling layer as a standalone Go binary with dual CLI and MCP support.
 * [Bundle Isolation and Mutation Security Boundaries](security-boundaries.md) - Defensive security architecture enforcing canonical bundle boundaries, symlink containment, path traversal prevention, and frontmatter injection defense.
+* [CLI Optional Path Boundary](cli-argument-boundary.md) - CLI commands consume an optional bundle or target path only from the first remaining argument, preserving all subsequent flag values.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,3 +1,6 @@
+## 2026-09-10
+* **Creation**: Documented concept `architecture/cli-argument-boundary.md` (CLI Optional Path Boundary).
+
 ## 2026-09-09
 * **Release**: Prepared version v0.1.5 — Adversarial Security & DRY Hardening Release integrating autonomous Google Jules adversarial security loop, boundary symlink containment, central DRY metadata sanitization, actor whitespace fallback, self-relation loop prevention, and Jules workflow automation (`jules-review`, `jules-merge`).
 


### PR DESCRIPTION
## Description
<!-- Briefly describe the goal and changes introduced by this pull request. -->

## Motivation & Context
<!-- Why is this change needed? What issue does it resolve? -->

## Changes Made
- [ ] 

## Verification & Pre-Submission Checklist
<!-- Please ensure all of the following checks pass locally: -->
- [ ] `make test` passes with 100% test success
- [ ] `make validate` passes on `knowledge/` (0 errors, 0 warnings, 0 orphans)
- [ ] `make validate-examples` passes on all sample corpora
- [ ] `make fmt` and `make vet` show clean code
- [ ] Any architectural or workflow changes are documented in `knowledge/`
