### PR TITLE
fix(relate): make links idempotent and log once

### DIFF
--- a/knowledge/architecture/index.md
+++ b/knowledge/architecture/index.md
@@ -3,3 +3,4 @@
 * [5-Layer System Architecture](layers.md) - Structural separation of concerns across the OKF specification, agent convention, skills, deterministic tooling, and knowledge corpus.
 * [Go Single-Binary CLI & MCP Architecture Decision](tooling-decision.md) - Architectural decision to implement the deterministic OKF tooling layer as a standalone Go binary with dual CLI and MCP support.
 * [Bundle Isolation and Mutation Security Boundaries](security-boundaries.md) - Defensive security architecture enforcing canonical bundle boundaries, symlink containment, path traversal prevention, and frontmatter injection defense.
+* [Relationship Identity and Logging](relationship-identity.md) - Relationships are identified by target path and description, making retries idempotent while retaining distinct relationship contexts.

--- a/knowledge/architecture/relationship-identity.md
+++ b/knowledge/architecture/relationship-identity.md
@@ -1,0 +1,11 @@
+---
+type: Decision
+title: Relationship Identity and Logging
+description: "Relationships are identified by target path and description, making retries idempotent while retaining distinct relationship contexts."
+tags: [relationships, idempotency, logging, mutation]
+generated: { by: agent/codex, at: "2026-09-10T04:09:21Z" }
+---
+
+# Relationship Identity and Logging
+
+An exact target-path and description pair is idempotent regardless of display-title changes. A successful new relationship emits one specific log entry. See [Bundle Isolation and Mutation Security Boundaries](security-boundaries.md).

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,3 +1,6 @@
+## 2026-09-10
+* **Creation**: Documented concept `architecture/relationship-identity.md` (Relationship Identity and Logging).
+
 ## 2026-09-09
 * **Release**: Prepared version v0.1.5 — Adversarial Security & DRY Hardening Release integrating autonomous Google Jules adversarial security loop, boundary symlink containment, central DRY metadata sanitization, actor whitespace fallback, self-relation loop prevention, and Jules workflow automation (`jules-review`, `jules-merge`).
 

--- a/pkg/okf/mutate.go
+++ b/pkg/okf/mutate.go
@@ -391,14 +391,13 @@ func RelateConcepts(bundleDir, sourceID, targetID, relationDesc, actor string) e
 	if relationDesc != "" {
 		relStatement = fmt.Sprintf("\n- [%s](%s): %s", linkText, relPath, relationDesc)
 	}
-
-	if !strings.Contains(srcConcept.Body, "# Related") {
-		srcConcept.Body = strings.TrimRight(srcConcept.Body, "\n") + "\n\n# Related Concepts" + relStatement + "\n"
-	} else {
-		srcConcept.Body = strings.TrimRight(srcConcept.Body, "\n") + relStatement + "\n"
+	if hasRelationship(srcConcept.Body, relPath, relationDesc) {
+		return nil
 	}
 
-	if err := SaveConcept(bundleDir, srcConcept, false, true, false, actor); err != nil {
+	srcConcept.Body = insertRelationship(srcConcept.Body, strings.TrimPrefix(relStatement, "\n"))
+
+	if err := SaveConcept(bundleDir, srcConcept, false, false, false, actor); err != nil {
 		return fmt.Errorf("failed to save related concept: %w", err)
 	}
 
@@ -407,4 +406,76 @@ func RelateConcepts(bundleDir, sourceID, targetID, relationDesc, actor string) e
 		logDesc = fmt.Sprintf("Linked `%s` to `%s` (%s).", srcConcept.Path, tgtConcept.Path, relationDesc)
 	}
 	return AppendLogEntry(bundleDir, "Update", logDesc)
+}
+
+func hasRelationship(body, relPath, relationDesc string) bool {
+	lines := strings.Split(body, "\n")
+	start, end, ok := relatedSectionBounds(lines)
+	if !ok {
+		return false
+	}
+	inFence := false
+	for _, line := range lines[start:end] {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "```") {
+			inFence = !inFence
+			continue
+		}
+		if inFence {
+			continue
+		}
+		if relationDesc == "" {
+			if strings.HasPrefix(trimmed, "- Related to [") && strings.HasSuffix(trimmed, "]("+relPath+")") {
+				return true
+			}
+			continue
+		}
+		if strings.HasPrefix(trimmed, "- [") && strings.HasSuffix(trimmed, "]("+relPath+"): "+relationDesc) {
+			return true
+		}
+	}
+	return false
+}
+
+func insertRelationship(body, relLine string) string {
+	lines := strings.Split(strings.TrimRight(body, "\n"), "\n")
+	_, end, ok := relatedSectionBounds(lines)
+	if !ok {
+		return strings.TrimRight(body, "\n") + "\n\n# Related Concepts\n" + relLine + "\n"
+	}
+
+	before := strings.TrimRight(strings.Join(lines[:end], "\n"), "\n")
+	after := strings.TrimLeft(strings.Join(lines[end:], "\n"), "\n")
+	if after == "" {
+		return before + "\n" + relLine + "\n"
+	}
+	return before + "\n" + relLine + "\n\n" + after + "\n"
+}
+
+func relatedSectionBounds(lines []string) (int, int, bool) {
+	inFence := false
+	start := -1
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "```") {
+			inFence = !inFence
+			continue
+		}
+		if inFence {
+			continue
+		}
+		if start == -1 {
+			if trimmed == "# Related Concepts" || trimmed == "# Related" {
+				start = i + 1
+			}
+			continue
+		}
+		if strings.HasPrefix(trimmed, "# ") {
+			return start, i, true
+		}
+	}
+	if start != -1 {
+		return start, len(lines), true
+	}
+	return 0, 0, false
 }

--- a/pkg/okf/okf_test.go
+++ b/pkg/okf/okf_test.go
@@ -196,6 +196,123 @@ func TestRelateConcepts(t *testing.T) {
 	if !strings.Contains(string(data), "[OAuth2 Flow](../auth/oauth.md)") {
 		t.Errorf("gateway.md missing relative link: %s", string(data))
 	}
+
+	if err := okf.RelateConcepts(tmpDir, "services/gateway", "auth/oauth", "verifies incoming tokens", "agent/test"); err != nil {
+		t.Fatalf("second RelateConcepts failed: %v", err)
+	}
+
+	data, err = os.ReadFile(filepath.Join(tmpDir, "services", "gateway.md"))
+	if err != nil {
+		t.Fatalf("Failed to re-read gateway.md: %v", err)
+	}
+	if got := strings.Count(string(data), "[OAuth2 Flow](../auth/oauth.md): verifies incoming tokens"); got != 1 {
+		t.Errorf("relationship appears %d times, want exactly once: %s", got, string(data))
+	}
+
+	logData, err := os.ReadFile(filepath.Join(tmpDir, "log.md"))
+	if err != nil {
+		t.Fatalf("Failed to read log.md: %v", err)
+	}
+	if got := strings.Count(string(logData), "Linked `services/gateway.md` to `auth/oauth.md`"); got != 1 {
+		t.Errorf("relationship log appears %d times, want exactly once: %s", got, string(logData))
+	}
+	if strings.Contains(string(logData), "Updated concept `services/gateway.md`.") {
+		t.Errorf("relation created a redundant generic update log: %s", string(logData))
+	}
+
+	if err := okf.RelateConcepts(tmpDir, "services/gateway", "auth/oauth", "verifies incoming tokens and roles", "agent/test"); err != nil {
+		t.Fatalf("RelateConcepts with a distinct description failed: %v", err)
+	}
+	data, err = os.ReadFile(filepath.Join(tmpDir, "services", "gateway.md"))
+	if err != nil {
+		t.Fatalf("Failed to read gateway.md after distinct relation: %v", err)
+	}
+	if got := strings.Count(string(data), "[OAuth2 Flow](../auth/oauth.md)"); got != 2 {
+		t.Errorf("distinct relationships produced %d links, want 2: %s", got, string(data))
+	}
+
+	c1.Title = "OAuth 2.0 Flow"
+	if err := okf.SaveConcept(tmpDir, c1, false, false, false, "agent/test"); err != nil {
+		t.Fatalf("SaveConcept after title change failed: %v", err)
+	}
+	if err := okf.RelateConcepts(tmpDir, "services/gateway", "auth/oauth", "verifies incoming tokens", "agent/test"); err != nil {
+		t.Fatalf("RelateConcepts after target title change failed: %v", err)
+	}
+	data, err = os.ReadFile(filepath.Join(tmpDir, "services", "gateway.md"))
+	if err != nil {
+		t.Fatalf("Failed to read gateway.md after target title change: %v", err)
+	}
+	if got := strings.Count(string(data), "](../auth/oauth.md)"); got != 2 {
+		t.Errorf("target title change duplicated an existing relationship: %s", string(data))
+	}
+}
+
+func TestRelateConceptsUsesCanonicalRelatedSection(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := okf.InitBundle(tmpDir); err != nil {
+		t.Fatalf("InitBundle failed: %v", err)
+	}
+
+	target := &okf.Concept{Path: "target.md", Type: "Fact", Title: "Target", Body: "# Target"}
+	source := &okf.Concept{
+		Path:  "source.md",
+		Type:  "Fact",
+		Title: "Source",
+		Body:  "# Source\n\n# Related Work\n\nBackground research.",
+	}
+	if err := okf.SaveConcept(tmpDir, target, true, false, false, "agent/test"); err != nil {
+		t.Fatalf("Save target failed: %v", err)
+	}
+	if err := okf.SaveConcept(tmpDir, source, true, false, false, "agent/test"); err != nil {
+		t.Fatalf("Save source failed: %v", err)
+	}
+
+	for i := 0; i < 2; i++ {
+		if err := okf.RelateConcepts(tmpDir, "source", "target", "supports", "agent/test"); err != nil {
+			t.Fatalf("RelateConcepts call %d failed: %v", i+1, err)
+		}
+	}
+	data, err := os.ReadFile(filepath.Join(tmpDir, "source.md"))
+	if err != nil {
+		t.Fatalf("Read source failed: %v", err)
+	}
+	content := string(data)
+	if strings.Count(content, "# Related Concepts") != 1 || strings.Count(content, "[Target](target.md): supports") != 1 {
+		t.Fatalf("canonical related section is not idempotent: %s", content)
+	}
+
+	source.Body = "# Source\n\n# Related Concepts\n\n- Existing relation\n\n# Notes\n\nKeep this last."
+	if err := okf.SaveConcept(tmpDir, source, false, false, false, "agent/test"); err != nil {
+		t.Fatalf("Reset source failed: %v", err)
+	}
+	if err := okf.RelateConcepts(tmpDir, "source", "target", "supports", "agent/test"); err != nil {
+		t.Fatalf("RelateConcepts before trailing section failed: %v", err)
+	}
+	data, err = os.ReadFile(filepath.Join(tmpDir, "source.md"))
+	if err != nil {
+		t.Fatalf("Read source after trailing section failed: %v", err)
+	}
+	content = string(data)
+	if strings.Index(content, "[Target](target.md): supports") > strings.Index(content, "# Notes") {
+		t.Fatalf("relationship was inserted outside the Related section: %s", content)
+	}
+
+	source.Body = "# Source\n\n# Related Concepts\n\n```markdown\n- [Target](target.md): illustrated only\n```"
+	if err := okf.SaveConcept(tmpDir, source, false, false, false, "agent/test"); err != nil {
+		t.Fatalf("Reset source with fenced example failed: %v", err)
+	}
+	for i := 0; i < 2; i++ {
+		if err := okf.RelateConcepts(tmpDir, "source", "target", "illustrated only", "agent/test"); err != nil {
+			t.Fatalf("RelateConcepts with fenced example call %d failed: %v", i+1, err)
+		}
+	}
+	data, err = os.ReadFile(filepath.Join(tmpDir, "source.md"))
+	if err != nil {
+		t.Fatalf("Read source with fenced example failed: %v", err)
+	}
+	if got := strings.Count(string(data), "[Target](target.md): illustrated only"); got != 2 {
+		t.Fatalf("fenced example suppressed or duplicated the real relationship: got %d occurrences\n%s", got, string(data))
+	}
 }
 
 func TestBootstrap(t *testing.T) {


### PR DESCRIPTION
## Description
<!-- Briefly describe the goal and changes introduced by this pull request. -->

## Motivation & Context
<!-- Why is this change needed? What issue does it resolve? -->

## Changes Made
- [ ] 

## Verification & Pre-Submission Checklist
<!-- Please ensure all of the following checks pass locally: -->
- [ ] `make test` passes with 100% test success
- [ ] `make validate` passes on `knowledge/` (0 errors, 0 warnings, 0 orphans)
- [ ] `make validate-examples` passes on all sample corpora
- [ ] `make fmt` and `make vet` show clean code
- [ ] Any architectural or workflow changes are documented in `knowledge/`
