### PR TITLE
fix(security): enforce search resource limits and control character validation

### DIFF
--- a/cmd/okf/mcp_test.go
+++ b/cmd/okf/mcp_test.go
@@ -189,6 +189,47 @@ func TestMCPToolCalls(t *testing.T) {
 	}
 }
 
+func TestMCPAdversarialSearchResourceLimits(t *testing.T) {
+	tmpDir := t.TempDir()
+	bundleDir := filepath.Join(tmpDir, "bundle")
+	_ = os.MkdirAll(bundleDir, 0o755)
+	_ = os.WriteFile(filepath.Join(bundleDir, "index.md"), []byte("---\nokf_version: \"0.2\"\n---\n# Bundle\n"), 0o644)
+	_ = os.WriteFile(filepath.Join(bundleDir, "log.md"), []byte("# Log\n"), 0o644)
+
+	hugeQuery := strings.Repeat("searchterm ", 200)
+
+	inputs := []string{
+		// 1. Search with massive limit parameter (e.g. 1,000,000)
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"okf_search","arguments":{"bundle":"` + bundleDir + `","query":"test","limit":1000000}}}`,
+		// 2. Search with oversized query string
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"okf_search","arguments":{"bundle":"` + bundleDir + `","query":"` + hugeQuery + `","limit":10}}}`,
+		// 3. Create concept with control character in concept_id
+		`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"okf_create","arguments":{"bundle":"` + bundleDir + `","concept_id":"ctrl\u0000concept","type":"Fact","title":"Ctrl","description":"Desc"}}}`,
+	}
+
+	responses := runMCPConversation(t, bundleDir, inputs)
+	if len(responses) != 3 {
+		t.Fatalf("Expected 3 responses, got %d", len(responses))
+	}
+
+	// Step 1 and 2 search queries should succeed cleanly without error
+	for i := 0; i < 2; i++ {
+		rMap, ok := responses[i].Result.(map[string]any)
+		if !ok || rMap["isError"] == true {
+			t.Errorf("Step %d search failed unexpectedly: %+v", i+1, responses[i])
+		}
+	}
+
+	// Step 3 (control char in concept_id) must return isError: true
+	step3Res, ok := responses[2].Result.(map[string]any)
+	if !ok {
+		t.Fatalf("Step 3 response result type invalid: %T", responses[2].Result)
+	}
+	if isError, _ := step3Res["isError"].(bool); !isError {
+		t.Errorf("Expected step 3 (control char concept_id) to return isError: true, got: %+v", step3Res)
+	}
+}
+
 func TestMCPAdversarialIndirectPromptInjectionInputs(t *testing.T) {
 	tmpDir := t.TempDir()
 	bundleDir := filepath.Join(tmpDir, "bundle")

--- a/pkg/okf/mutate.go
+++ b/pkg/okf/mutate.go
@@ -84,6 +84,10 @@ func ValidateConceptID(id string) error {
 		return fmt.Errorf("concept ID cannot be empty")
 	}
 
+	if strings.ContainsAny(trimmed, "\x00\r\n\t") {
+		return fmt.Errorf("concept ID %q contains forbidden control characters", id)
+	}
+
 	cleanID := strings.TrimSuffix(trimmed, ".md")
 	if cleanID == "" || cleanID == "." || cleanID == ".." {
 		return fmt.Errorf("invalid concept ID %q", id)

--- a/pkg/okf/mutate_security_test.go
+++ b/pkg/okf/mutate_security_test.go
@@ -661,3 +661,61 @@ func TestSaveConceptActorWhitespaceFallback(t *testing.T) {
 		t.Errorf("Expected trimmed actor 'agent/custom', got %+v", c2.Generated)
 	}
 }
+
+// TestValidateConceptIDControlCharacters verifies that concept IDs containing null bytes or control chars are rejected.
+func TestValidateConceptIDControlCharacters(t *testing.T) {
+	controlCases := []string{
+		"concept\x00id",
+		"concept\r\nid",
+		"concept\tid",
+		"sub/\x00/concept",
+	}
+
+	for _, id := range controlCases {
+		if err := ValidateConceptID(id); err == nil {
+			t.Errorf("ValidateConceptID(%q) expected error for control characters, got nil", id)
+		}
+	}
+}
+
+// TestSearchResourceLimits verifies that Search enforces maximum limit caps and truncates oversized query strings.
+func TestSearchResourceLimits(t *testing.T) {
+	bundleDir := t.TempDir()
+	if err := InitBundle(bundleDir); err != nil {
+		t.Fatalf("InitBundle failed: %v", err)
+	}
+
+	for i := 0; i < 150; i++ {
+		c := &Concept{
+			ID:          filepath.Join("items", strings.Repeat("a", 10)+"-"+string(rune('a'+i%26))+"-"+strings.Repeat("x", i%10)),
+			Path:        filepath.Join("items", strings.Repeat("a", 10)+"-"+string(rune('a'+i%26))+"-"+strings.Repeat("x", i%10)+".md"),
+			Title:       "Test Concept " + string(rune('A'+i%26)),
+			Type:        "Fact",
+			Description: "Common search target term for testing limits.",
+			Body:        "Body containing common search target term.",
+		}
+		c.Path = filepath.ToSlash(c.Path)
+		c.ID = filepath.ToSlash(c.ID)
+		if err := SaveConcept(bundleDir, c, true, false, false, "test"); err != nil {
+			t.Fatalf("SaveConcept %d failed: %v", i, err)
+		}
+	}
+
+	b, err := LoadBundle(bundleDir)
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	// 1. Oversized limit parameter (e.g. 100000) should be capped at MaxSearchLimit (100)
+	results := b.Search("common search target term", 100000)
+	if len(results) > MaxSearchLimit {
+		t.Errorf("Expected at most %d search results, got %d", MaxSearchLimit, len(results))
+	}
+
+	// 2. Oversized query string (> 1000 chars) should be handled safely
+	hugeQuery := strings.Repeat("term ", 500)
+	hugeResults := b.Search(hugeQuery, 10)
+	if hugeResults == nil {
+		t.Errorf("Expected search with huge query string to return results, got nil")
+	}
+}

--- a/pkg/okf/search.go
+++ b/pkg/okf/search.go
@@ -36,12 +36,15 @@ func tokenize(s string) []string {
 // MaxSearchLimit defines the maximum allowable search results returned to prevent resource exhaustion.
 const MaxSearchLimit = 100
 
+// MaxQueryLength defines the maximum query string length in runes/bytes evaluated to prevent resource exhaustion.
+const MaxQueryLength = 1000
+
 // Search queries the bundle using in-memory BM25/TF-IDF token scoring over frontmatter and body.
 func (b *Bundle) Search(query string, limit int) []SearchResult {
-	if len(query) > 1000 {
+	if len(query) > MaxQueryLength {
 		runes := []rune(query)
-		if len(runes) > 1000 {
-			query = string(runes[:1000])
+		if len(runes) > MaxQueryLength {
+			query = string(runes[:MaxQueryLength])
 		}
 	}
 

--- a/pkg/okf/search.go
+++ b/pkg/okf/search.go
@@ -33,15 +33,30 @@ func tokenize(s string) []string {
 	return out
 }
 
+// MaxSearchLimit defines the maximum allowable search results returned to prevent resource exhaustion.
+const MaxSearchLimit = 100
+
 // Search queries the bundle using in-memory BM25/TF-IDF token scoring over frontmatter and body.
 func (b *Bundle) Search(query string, limit int) []SearchResult {
+	if len(query) > 1000 {
+		runes := []rune(query)
+		if len(runes) > 1000 {
+			query = string(runes[:1000])
+		}
+	}
+
 	qTokens := tokenize(query)
 	if len(qTokens) == 0 {
 		return nil
 	}
+	if len(qTokens) > 50 {
+		qTokens = qTokens[:50]
+	}
 
 	if limit <= 0 {
 		limit = 10
+	} else if limit > MaxSearchLimit {
+		limit = MaxSearchLimit
 	}
 
 	N := float64(len(b.Concepts))


### PR DESCRIPTION
### Security Audit Finding & Remediation Report

#### Finding & CWE Category
1. **Search Resource Limits & Algorithmic Bounds (CWE-400)**: Unbounded search limit parameters and oversized query strings could allow resource exhaustion in BM25 scoring over bundle concepts.
2. **Concept ID Control Character Validation (CWE-20 / CWE-22)**: Concept IDs containing control characters (`\x00`, `\r`, `\n`, `\t`) could trigger unexpected filesystem or logging behaviors.

#### Implemented Remediation & Tests Added
- **`pkg/okf/search.go`**:
  - Enforced `MaxSearchLimit = 100` upper bound on search result limits.
  - Truncated query strings exceeding 1,000 runes safely.
  - Capped query token count `qTokens` to at most 50 tokens.
- **`pkg/okf/mutate.go`**:
  - Added strict control character rejection in `ValidateConceptID`.
- **Tests Added**:
  - `TestSearchResourceLimits` and `TestValidateConceptIDControlCharacters` in `pkg/okf/mutate_security_test.go`.
  - `TestMCPAdversarialSearchResourceLimits` in `cmd/okf/mcp_test.go` verifying MCP tool calls with oversized limits, long queries, and control character parameters.

---
*PR created automatically by Jules for task [17124628924921991392](https://jules.google.com/task/17124628924921991392) started by @sknr*