### PR TITLE
fix(security): sanitize Windows backslash path traversal cross-platform

### DIFF
--- a/cmd/okf/mcp.go
+++ b/cmd/okf/mcp.go
@@ -393,11 +393,12 @@ func (s *mcpServer) resolveBundleDir(callParams mcpToolCallParams) (string, erro
 			absRoot, _ = filepath.Abs(absRoot)
 		}
 
+		normTarget := strings.ReplaceAll(target, "\\", "/")
 		var absTarget string
-		if filepath.IsAbs(target) {
-			absTarget = target
+		if filepath.IsAbs(normTarget) {
+			absTarget = normTarget
 		} else {
-			absTarget = filepath.Join(s.rootDir, target)
+			absTarget = filepath.Join(s.rootDir, normTarget)
 		}
 
 		// Walk up to find the closest ancestor that exists and evaluate its symlinks
@@ -429,7 +430,8 @@ func (s *mcpServer) resolveBundleDir(callParams mcpToolCallParams) (string, erro
 		realTarget := filepath.Join(parts...)
 
 		rel, err := filepath.Rel(absRoot, realTarget)
-		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		relSlash := filepath.ToSlash(rel)
+		if err != nil || relSlash == ".." || strings.HasPrefix(relSlash, "../") {
 			return "", fmt.Errorf("bundle directory %q escapes server root %q", target, s.rootDir)
 		}
 

--- a/cmd/okf/mcp_test.go
+++ b/cmd/okf/mcp_test.go
@@ -676,3 +676,37 @@ code_refs: ["pkg/**/*.go"]
 		t.Errorf("Expected governance 'constraint', got %q", results[0].Governance)
 	}
 }
+
+func TestMCPBundle_BackslashTraversalDenied(t *testing.T) {
+	tmpDir := t.TempDir()
+	serverRoot := filepath.Join(tmpDir, "server")
+	bundleDir := filepath.Join(serverRoot, "knowledge")
+	outsideDir := filepath.Join(tmpDir, "outside")
+	_ = os.MkdirAll(bundleDir, 0o755)
+	_ = os.MkdirAll(outsideDir, 0o755)
+	_ = os.WriteFile(filepath.Join(bundleDir, "index.md"), []byte("---\nokf_version: \"0.2\"\n---\n# Root\n"), 0o644)
+	_ = os.WriteFile(filepath.Join(bundleDir, "log.md"), []byte("# Log\n"), 0o644)
+
+	inputs := []string{
+		// Attempt bundle traversal via backslashes ..\..\outside
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"okf_search","arguments":{"bundle":"..\\..\\outside","query":"test"}}}`,
+		// Attempt create in bundle traversal via backslashes
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"okf_create","arguments":{"bundle":"..\\..\\outside","concept_id":"evil","type":"Fact","title":"Evil","description":"Should fail"}}}`,
+	}
+
+	responses := runMCPConversation(t, bundleDir, inputs)
+	if len(responses) != len(inputs) {
+		t.Fatalf("Expected %d responses, got %d", len(inputs), len(responses))
+	}
+
+	for i, r := range responses {
+		rMap, ok := r.Result.(map[string]any)
+		if !ok {
+			t.Fatalf("Response %d has unexpected result type: %T", i+1, r.Result)
+		}
+		isError, _ := rMap["isError"].(bool)
+		if !isError {
+			t.Errorf("Expected response %d to have isError: true, got: %+v", i+1, rMap)
+		}
+	}
+}

--- a/pkg/okf/bundle.go
+++ b/pkg/okf/bundle.go
@@ -52,7 +52,14 @@ func ensureWithinRoot(rootDir, targetPath string) (string, error) {
 		return "", fmt.Errorf("failed to get absolute path of bundle root: %w", err)
 	}
 
-	absTarget, err := filepath.Abs(targetPath)
+	cleanTarget := strings.ReplaceAll(targetPath, "\\", "/")
+	if filepath.IsAbs(targetPath) {
+		cleanTarget = filepath.Clean(cleanTarget)
+	} else {
+		cleanTarget = path.Join(filepath.ToSlash(realRoot), cleanTarget)
+	}
+
+	absTarget, err := filepath.Abs(filepath.FromSlash(cleanTarget))
 	if err != nil {
 		return "", err
 	}
@@ -86,7 +93,8 @@ func ensureWithinRoot(rootDir, targetPath string) (string, error) {
 	realTarget := filepath.Join(parts...)
 
 	rel, err := filepath.Rel(realRoot, realTarget)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+	relSlash := filepath.ToSlash(rel)
+	if err != nil || relSlash == ".." || strings.HasPrefix(relSlash, "../") {
 		return "", fmt.Errorf("path traversal denied: %q escapes bundle directory", targetPath)
 	}
 

--- a/pkg/okf/mutate.go
+++ b/pkg/okf/mutate.go
@@ -3,6 +3,7 @@ package okf
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -132,15 +133,17 @@ func UpdateParentIndex(bundleDir string, c *Concept) error {
 		return fmt.Errorf("invalid bundle directory: %w", err)
 	}
 
-	dir := filepath.Dir(c.Path)
+	normConceptPath := strings.ReplaceAll(c.Path, "\\", "/")
+	dir := path.Dir(normConceptPath)
 	indexRelPath := "index.md"
 	if dir != "." {
-		indexRelPath = filepath.Join(dir, "index.md")
+		indexRelPath = filepath.Join(filepath.FromSlash(dir), "index.md")
 	}
 
 	indexPath := filepath.Join(absBundle, filepath.Clean(indexRelPath))
 	rel, err := filepath.Rel(absBundle, indexPath)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+	relSlash := strings.ReplaceAll(rel, "\\", "/")
+	if err != nil || relSlash == ".." || strings.HasPrefix(relSlash, "../") {
 		return fmt.Errorf("path traversal denied: parent index %q escapes bundle directory", indexRelPath)
 	}
 	if _, err := ensureWithinRoot(bundleDir, indexPath); err != nil {
@@ -205,13 +208,15 @@ func resolveInBundle(bundleDir, relPath string) (string, error) {
 		return "", fmt.Errorf("failed to resolve bundle directory: %w", err)
 	}
 
-	cleanRel := filepath.Clean(relPath)
+	normRelPath := strings.ReplaceAll(relPath, "\\", "/")
+	cleanRel := filepath.Clean(filepath.FromSlash(normRelPath))
 	full := filepath.Join(absBundle, cleanRel)
 	rel, err := filepath.Rel(absBundle, full)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve concept path %q: %w", relPath, err)
 	}
-	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+	relSlash := strings.ReplaceAll(rel, "\\", "/")
+	if relSlash == ".." || strings.HasPrefix(relSlash, "../") {
 		return "", fmt.Errorf("path traversal denied: concept path %q escapes bundle directory", relPath)
 	}
 	// Check reserved filenames on relative path (index.md anywhere, root log.md, root AGENTS.md)

--- a/pkg/okf/mutate_security_test.go
+++ b/pkg/okf/mutate_security_test.go
@@ -719,3 +719,39 @@ func TestSearchResourceLimits(t *testing.T) {
 		t.Errorf("Expected search with huge query string to return results, got nil")
 	}
 }
+
+// TestEnsureWithinRootWindowsBackslashTraversal verifies cross-platform path traversal containment
+// for Windows-style backslashes (..\..) on all operating systems.
+func TestEnsureWithinRootWindowsBackslashTraversal(t *testing.T) {
+	root := t.TempDir()
+	bundleDir := filepath.Join(root, "knowledge")
+	if err := InitBundle(bundleDir); err != nil {
+		t.Fatalf("InitBundle: %v", err)
+	}
+
+	backslashPaths := []string{
+		"..\\..\\evil.md",
+		"sub\\..\\..\\evil.md",
+		"a\\b\\..\\..\\..\\evil.md",
+	}
+
+	for _, p := range backslashPaths {
+		target := filepath.Join(bundleDir, p)
+		if _, err := ensureWithinRoot(bundleDir, target); err == nil {
+			t.Errorf("ensureWithinRoot(%q): expected path traversal error for backslash path, got nil", p)
+		}
+
+		c := &Concept{
+			ID:    "evil",
+			Path:  p,
+			Type:  "Fact",
+			Title: "Evil",
+		}
+		if err := SaveConcept(bundleDir, c, true, false, false, "test"); err == nil {
+			t.Errorf("SaveConcept(%q): expected path traversal error for backslash path, got nil", p)
+		}
+		if err := UpdateParentIndex(bundleDir, c); err == nil {
+			t.Errorf("UpdateParentIndex(%q): expected path traversal error for backslash path, got nil", p)
+		}
+	}
+}


### PR DESCRIPTION
### Finding & CWE Category
- **CWE-22 (Improper Limitation of a Pathname to a Restricted Directory / Path Traversal)**
- **CWE-59 (Improper Link Resolution Before File Access)**

### Exploitation Scenario / Risk
On POSIX platforms (Linux/macOS), Go's `filepath.ToSlash` is a no-op because `filepath.Separator` is `/`. When malicious path parameters containing Windows-style backslash traversal sequences (e.g. `..\..\outside` or `sub\..\..\evil.md`) were passed into `ensureWithinRoot`, `resolveInBundle`, `UpdateParentIndex`, or MCP `resolveBundleDir`, the `filepath.Rel` check failed to identify path escaping because backslashes were treated as standard path literal characters.

An attacker could potentially bypass bundle directory boundary checks and MCP server root confinement on POSIX hosts using backslash path payloads.

### Implemented Remediation & Tests Added
1. **Explicit Backslash Normalization**:
   - Replaced input path backslashes with slashes using `strings.ReplaceAll(path, "\\", "/")` prior to running `filepath.Clean` and `filepath.Rel` evaluation in `pkg/okf/bundle.go` (`ensureWithinRoot`), `pkg/okf/mutate.go` (`resolveInBundle`, `UpdateParentIndex`), and `cmd/okf/mcp.go` (`resolveBundleDir`).
2. **Adversarial Unit Tests**:
   - `pkg/okf/mutate_security_test.go`: Added `TestEnsureWithinRootWindowsBackslashTraversal` to test `ensureWithinRoot`, `SaveConcept`, and `UpdateParentIndex` against Windows-style backslash traversal sequences across operating systems.
   - `cmd/okf/mcp_test.go`: Added `TestMCPBundle_BackslashTraversalDenied` to test MCP tool invocation against backslash traversal paths in the `bundle` argument.

---
*PR created automatically by Jules for task [8781493661620086046](https://jules.google.com/task/8781493661620086046) started by @sknr*